### PR TITLE
#387 Fixed typo: Changed artefact to artifact

### DIFF
--- a/releasenotes/releasenotes_develop.md
+++ b/releasenotes/releasenotes_develop.md
@@ -1,9 +1,8 @@
 # Release Notes x.x.x
 
-This is the first release of the keptn installer, which has been extraced from the [keptn repository](https://github.com/keptn/keptn) into a dedicated installer repository.
-
 ## New Features
 
 ## Fixed Issues
+- Fixed typo: Changed _art**e**fact_ to _art**i**fact_ [#387](https://github.com/keptn/keptn/issues/387)
 
 ## Known Limitations

--- a/scripts/setupKeptn.sh
+++ b/scripts/setupKeptn.sh
@@ -27,9 +27,9 @@ kubectl apply -f https://raw.githubusercontent.com/keptn/eventbroker/$EVENTBROKE
 verify_kubectl $? "Creating keptn-channel channel failed."
 wait_for_channel_in_namespace "keptn-channel" "keptn"
 
-kubectl apply -f https://raw.githubusercontent.com/keptn/eventbroker/$EVENTBROKER_RELEASE/config/new-artefact-channel.yaml
-verify_kubectl $? "Creating new-artefact channel failed."
-wait_for_channel_in_namespace "new-artefact" "keptn"
+kubectl apply -f https://raw.githubusercontent.com/keptn/eventbroker/$EVENTBROKER_RELEASE/config/new-artifact-channel.yaml
+verify_kubectl $? "Creating new-artifact channel failed."
+wait_for_channel_in_namespace "new-artifact" "keptn"
 
 kubectl apply -f https://raw.githubusercontent.com/keptn/eventbroker/$EVENTBROKER_RELEASE/config/configuration-changed-channel.yaml
 verify_kubectl $? "Creating configuration-changed channel failed."


### PR DESCRIPTION
This PR ensures a consistent use of the word artifact instead of artefact across all keptn repositories.