### PR TITLE
Set visibility of helm-service to cluster-local

### DIFF
--- a/manifests/keptn/uniform.yaml
+++ b/manifests/keptn/uniform.yaml
@@ -121,6 +121,8 @@ kind: Service
 metadata:
   name: helm-service
   namespace: keptn
+  labels:
+    serving.knative.dev/visibility: cluster-local
 spec:
   runLatest:
     configuration:


### PR DESCRIPTION
To not expose the helm-service, set visibility of helm-service to cluster-local.