### PR TITLE
#444 Re-add creating the clusterrolebinding `keptn-cluster-admin-binding`

### DIFF
--- a/manifests/installer/installer.yaml
+++ b/manifests/installer/installer.yaml
@@ -17,7 +17,7 @@ spec:
         emptyDir: {}
       containers:
       - name: keptn-installer
-        image: keptn/installer:cfb210d
+        image: keptn/installer:c23a24c
         env: 
         - name: CLUSTER_IPV4_CIDR
           value: CLUSTER_IPV4_CIDR

--- a/manifests/installer/installer.yaml
+++ b/manifests/installer/installer.yaml
@@ -17,7 +17,7 @@ spec:
         emptyDir: {}
       containers:
       - name: keptn-installer
-        image: keptn/installer:e0356f1
+        image: keptn/installer:latest
         env: 
         - name: CLUSTER_IPV4_CIDR
           value: CLUSTER_IPV4_CIDR

--- a/manifests/installer/installer.yaml
+++ b/manifests/installer/installer.yaml
@@ -17,7 +17,7 @@ spec:
         emptyDir: {}
       containers:
       - name: keptn-installer
-        image: keptn/installer:775e1ec
+        image: keptn/installer:latest
         env: 
         - name: CLUSTER_IPV4_CIDR
           value: CLUSTER_IPV4_CIDR

--- a/manifests/installer/installer.yaml
+++ b/manifests/installer/installer.yaml
@@ -17,7 +17,7 @@ spec:
         emptyDir: {}
       containers:
       - name: keptn-installer
-        image: keptn/installer:latest
+        image: keptn/installer:775e1ec
         env: 
         - name: CLUSTER_IPV4_CIDR
           value: CLUSTER_IPV4_CIDR

--- a/manifests/installer/installer.yaml
+++ b/manifests/installer/installer.yaml
@@ -17,7 +17,7 @@ spec:
         emptyDir: {}
       containers:
       - name: keptn-installer
-        image: keptn/installer:7063106
+        image: keptn/installer:cfb210d
         env: 
         - name: CLUSTER_IPV4_CIDR
           value: CLUSTER_IPV4_CIDR

--- a/manifests/installer/installer.yaml
+++ b/manifests/installer/installer.yaml
@@ -17,7 +17,7 @@ spec:
         emptyDir: {}
       containers:
       - name: keptn-installer
-        image: keptn/installer:latest
+        image: keptn/installer:7063106
         env: 
         - name: CLUSTER_IPV4_CIDR
           value: CLUSTER_IPV4_CIDR

--- a/manifests/installer/installer.yaml
+++ b/manifests/installer/installer.yaml
@@ -17,7 +17,7 @@ spec:
         emptyDir: {}
       containers:
       - name: keptn-installer
-        image: keptn/installer:c23a24c
+        image: keptn/installer:e0356f1
         env: 
         - name: CLUSTER_IPV4_CIDR
           value: CLUSTER_IPV4_CIDR

--- a/scripts/installKeptn.sh
+++ b/scripts/installKeptn.sh
@@ -89,7 +89,7 @@ verify_kubectl $? "Could not connect to Kubernetes API."
 print_info "Connection to Kubernetes API successful"
 
 # Grant cluster admin rights to gcloud user
-#kubectl create clusterrolebinding keptn-cluster-admin-binding --clusterrole=cluster-admin --user=$GCLOUD_USER
+kubectl create clusterrolebinding keptn-cluster-admin-binding --clusterrole=cluster-admin --user=$GCLOUD_USER
 verify_kubectl $? "Cluster role binding could not be created."
 
 # Create keptn namespaces

--- a/scripts/setupKeptn.sh
+++ b/scripts/setupKeptn.sh
@@ -46,12 +46,6 @@ cat ../manifests/knative/config-domain.yaml | \
 kubectl apply -f ../manifests/gen/config-domain.yaml --wait
 verify_kubectl $? "Creating configmap config-domain in knative-serving namespace failed."
 
-# Add debug message
-echo "applied config-map"
-cat ../manifests/gen/config-domain.yaml
-echo "Get configmap config-domain"
-kubectl get cm config-domain -n knative-serving -oyaml
-
 # Creating cluster role binding
 kubectl apply -f ../manifests/keptn/rbac.yaml
 verify_kubectl $? "Creating cluster role for keptn failed."

--- a/scripts/setupKeptn.sh
+++ b/scripts/setupKeptn.sh
@@ -46,6 +46,12 @@ cat ../manifests/knative/config-domain.yaml | \
 kubectl apply -f ../manifests/gen/config-domain.yaml --wait
 verify_kubectl $? "Creating configmap config-domain in knative-serving namespace failed."
 
+# Add debug message
+echo "applied config-map"
+cat ../manifests/gen/config-domain.yaml
+echo "Get configmap config-domain"
+kubectl get cm config-domain -n knative-serving -oyaml
+
 # Creating cluster role binding
 kubectl apply -f ../manifests/keptn/rbac.yaml
 verify_kubectl $? "Creating cluster role for keptn failed."
@@ -89,5 +95,6 @@ verify_kubectl $? "Deploying keptn core components failed."
 wait_for_all_pods_in_namespace "keptn"
 
 wait_for_deployment_in_namespace "event-broker" "keptn" # Wait function also waits for eventbroker-ext
-wait_for_deployment_in_namespace "auth" "keptn"
+wait_for_deployment_in_namespace "authenticator" "keptn"
 wait_for_deployment_in_namespace "control" "keptn"
+wait_for_deployment_in_namespace "bridge" "keptn"

--- a/scripts/setupKeptn.sh
+++ b/scripts/setupKeptn.sh
@@ -34,7 +34,7 @@ rm ../manifests/gen/keptn-domain-configmap.yaml
 cat ../manifests/keptn/keptn-domain-configmap.yaml | \
   sed 's~DOMAIN_PLACEHOLDER~'"$DOMAIN"'~' >> ../manifests/gen/keptn-domain-configmap.yaml
 
-kubectl apply -f ../manifests/gen/keptn-domain-configmap.yaml
+kubectl apply -f ../manifests/gen/keptn-domain-configmap.yaml --wait
 verify_kubectl $? "Creating configmap keptn-domain in keptn namespace failed."
 
 # Configure knative serving default domain
@@ -43,7 +43,7 @@ rm -f ../manifests/gen/config-domain.yaml
 cat ../manifests/knative/config-domain.yaml | \
   sed 's~DOMAIN_PLACEHOLDER~'"$DOMAIN"'~' >> ../manifests/gen/config-domain.yaml
 
-kubectl apply -f ../manifests/gen/config-domain.yaml
+kubectl apply -f ../manifests/gen/config-domain.yaml --wait
 verify_kubectl $? "Creating configmap config-domain in knative-serving namespace failed."
 
 # Creating cluster role binding
@@ -80,7 +80,7 @@ rm -f ../manifests/keptn/gen/core.yaml
 cat ../manifests/keptn/core.yaml | \
   sed 's~CHANNEL_URI_PLACEHOLDER~'"$KEPTN_CHANNEL_URI"'~' >> ../manifests/keptn/gen/core.yaml
   
-kubectl apply -f ../manifests/keptn/gen/core.yaml
+kubectl apply -f ../manifests/keptn/gen/core.yaml --wait
 verify_kubectl $? "Deploying keptn core components failed."
 
 ##############################################

--- a/scripts/wearUniform.sh
+++ b/scripts/wearUniform.sh
@@ -2,7 +2,7 @@
 source ./utils.sh
 
 # Deploy uniform
-kubectl apply -f ../manifests/keptn/uniform.yaml
+kubectl apply -f ../manifests/keptn/uniform.yaml --wait
 verify_kubectl $? "Deploying keptn's uniform failed."
 
 ##############################################


### PR DESCRIPTION
This clusterrolebinding is necessary as otherwise the installation is not working. For example, the `config-domain` in the `knative` namespace is not created properly.